### PR TITLE
Augment error on non 200 responses with full response

### DIFF
--- a/transifex.js
+++ b/transifex.js
@@ -24,7 +24,10 @@ Transifex.prototype.projectRequest = function(url, options, callback) {
       return callback(error);
     }
     if (response.statusCode !== 200) {
-      return callback(Error(url + " returned " + response.statusCode));
+      var responseError = new Error(url + " returned " + response.statusCode);
+      responseError.response = response;
+
+      return callback(responseError);
     }
     if(response.headers['content-disposition']) {
       var str = response.headers['content-disposition'];


### PR DESCRIPTION
So i dug a bit deeper to see why the tests fail, and it turns out that the tests run into the API rate limit and therefore 503 is returned when running the tests for the last two tests. When you run them alone and if you're not currently limited they work just fine.

Not much you can do about it I guess, unless Transifex raises the limit or we mock the replies from them. 

Anyway, while digging I found these lines: https://github.com/alicoding/node-transifex/blob/617a84c3c61f0e6274f385ea49ee345a0870acc5/transifex.js#L26-L28. I think it would be nicer to wrap the whole response in the Error, so you can instantly see what the body says (and in our case, instantly see that it's about the rate limit and not us doing something wrong)

So this PR basically just does that, let me know what you think :)