### PR TITLE
Update translationStringMethod to request a single string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "5.9.1"

--- a/README.md
+++ b/README.md
@@ -305,9 +305,10 @@ transifex.translationInstanceMethod("webmaker", "profile", "zh_CN", { mode: "rev
 #### translationStringsMethod
 
 The `translationStringsMethod` function returns the requested translation strings, if they exists. The translation strings are returned as `json`.
+The `string-to-translate` parameter is optional. If this is not provided, the request will return all strings for the specified language code.
 
 ``` javascript
-transifex.translationStringsMethod("webmaker", "profile", "cs", function(err, data) {
+transifex.translationStringsMethod("webmaker", "profile", "cs", "string-to-translate", function(err, data) {
   ...
 });
 ```

--- a/tests/good-api-test.js
+++ b/tests/good-api-test.js
@@ -234,6 +234,7 @@ describe("Translations API", function () {
         try {
           data = JSON.parse(data);
           data[0].should.have.properties('comment', 'context', 'tags', 'source_string', 'translation', 'last_update');
+          data.length.should.be.equal(1);
           data[0].translation.should.be.equal("Das ist cool. Super cool!");
         } catch(e) {
           done();

--- a/tests/good-api-test.js
+++ b/tests/good-api-test.js
@@ -228,6 +228,21 @@ describe("Translations API", function () {
     }).not.throw();
   });
 
+  it("translationStringsMethod specific string", function (done) {
+    should(function(){
+      transifex.translationStringsMethod("node-transifex-sample", "source-file", "de", "This is cool. Super Cool!", function(err, data) {
+        try {
+          data = JSON.parse(data);
+          data[0].should.have.properties('comment', 'context', 'tags', 'source_string', 'translation', 'last_update');
+          data[0].translation.should.be.equal("Das ist cool. Super cool!");
+        } catch(e) {
+          done();
+        }
+        done();
+      });
+    }).not.throw();
+  });
+
 });
 
 describe("Statistics API", function () {

--- a/tests/good-api-test.js
+++ b/tests/good-api-test.js
@@ -216,7 +216,7 @@ describe("Translations API", function () {
 
   it("translationStringsMethod", function (done) {
     should(function(){
-      transifex.translationStringsMethod("node-transifex-sample", "source-file", "de", function(err, data) {
+      transifex.translationStringsMethod("node-transifex-sample", "source-file", "de", "test", function(err, data) {
         try {
           data = JSON.parse(data);
           data[0].should.have.properties('comment', 'context', 'tags', 'source_string', 'translation', 'last_update');

--- a/transifex.js
+++ b/transifex.js
@@ -420,11 +420,13 @@ Transifex.prototype.translationInstanceMethod = function(project_slug, resource_
 };
 
 
-Transifex.prototype.translationStringsMethod = function(project_slug, resource_slug, language_code, callback) {
+Transifex.prototype.translationStringsMethod = function(project_slug, resource_slug, language_code, string_key, callback) {
   project_slug = project_slug || this.projectSlug || "webmaker";
+  string_key = string_key || '';
   var url = this.expUrl.translationStringsURL.replace("<project_slug>", project_slug)
                                         .replace("<resource_slug>", resource_slug)
-                                        .replace("<language_code>", language_code);
+                                        .replace("<language_code>", language_code)
+                                        .replace("<string_key>", string_key ? "&key=" + string_key : '');
   this.projectRequest(url, function(err, content) {
     if (err) {
       return callback(err);

--- a/url.js
+++ b/url.js
@@ -15,7 +15,7 @@ module.exports = function ( projectName ) {
     languageInstanceURL: plSlug + "?details",
     contributorForURL: plSlug + "<type>/",
     translationMethodURL: prSlug + "translation/<language_code>/?file",
-    translationStringsURL: prSlug + "translation/<language_code>/strings?details",
+    translationStringsURL: prSlug + "translation/<language_code>/strings/?details<string_key>",
     statsMethodURL: prSlug + "stats/<language_code>/",
     languageURL: BASE_URL + "language/<language_code>/",
     languagesURL: BASE_URL + "languages/",


### PR DESCRIPTION
### Problem: 
I am unable to request a single string translation from Transifex's API, which increases the response's payload and causes unnecessary complexity when parsing the final result.

### Solution:
I have extended the `translationStringMethod` method to accept an optional `string` argument that can specify to Transifex's API exactly what translation the user is looking for.

### Notes:
I have added an appropriate test and updated the README markdown to document the new change.
