### PR TITLE
remove prefer global from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "node transifex",
     "transifex API"
   ],
-  "preferGlobal": true,
   "author": "Ali Al Dallal <ali@alicoding.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
removed `preferGlobal` flag from `package.json`. removes warning when node-transifex is used as a project level module.

addresses https://github.com/alicoding/node-transifex/issues/9